### PR TITLE
Custom symbol define release_test

### DIFF
--- a/src/components.cs
+++ b/src/components.cs
@@ -166,7 +166,7 @@ namespace Leopotam.EcsLite {
             _sparseItems[entity] = idx;
             _world.OnEntityChangeInternal (entity, _id, true);
             _world.Entities[entity].ComponentsCount++;
-#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
+#if (DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS) || LEOECSLITE_WORLD_EVENTS
             _world.RaiseEntityChangeEvent (entity);
 #endif
             return ref _denseItems[idx];
@@ -208,7 +208,7 @@ namespace Leopotam.EcsLite {
                 sparseData = 0;
                 ref var entityData = ref _world.Entities[entity];
                 entityData.ComponentsCount--;
-#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
+#if (DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS) || LEOECSLITE_WORLD_EVENTS
                 _world.RaiseEntityChangeEvent (entity);
 #endif
                 if (entityData.ComponentsCount == 0) {

--- a/src/components.cs
+++ b/src/components.cs
@@ -56,14 +56,14 @@ namespace Leopotam.EcsLite {
             _recycledItems = new int[recycledCapacity];
             _recycledItemsCount = 0;
             var isAutoReset = typeof (IEcsAutoReset<T>).IsAssignableFrom (_type);
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (!isAutoReset && _type.GetInterface ("IEcsAutoReset`1") != null) {
                 throw new Exception ($"IEcsAutoReset should have <{typeof (T).Name}> constraint for component \"{typeof (T).Name}\".");
             }
 #endif
             if (isAutoReset) {
                 var autoResetMethod = typeof (T).GetMethod (nameof (IEcsAutoReset<T>.AutoReset));
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                 if (autoResetMethod == null) {
                     throw new Exception (
                         $"IEcsAutoReset<{typeof (T).Name}> explicit implementation not supported, use implicit instead.");
@@ -112,7 +112,7 @@ namespace Leopotam.EcsLite {
         }
 
         void IEcsPool.SetRaw (int entity, object dataRaw) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (dataRaw == null || dataRaw.GetType () != _type) { throw new Exception ("Invalid component data."); }
             if (_sparseItems[entity] <= 0) { throw new Exception ("Component not attached to entity."); }
 #endif
@@ -120,7 +120,7 @@ namespace Leopotam.EcsLite {
         }
 
         void IEcsPool.AddRaw (int entity, object dataRaw) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (dataRaw == null || dataRaw.GetType () != _type) { throw new Exception ("Invalid component data."); }
 #endif
             ref var data = ref Add (entity);
@@ -148,7 +148,7 @@ namespace Leopotam.EcsLite {
         }
 
         public ref T Add (int entity) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (!_world.IsEntityAliveInternal (entity)) { throw new Exception ("Cant touch destroyed entity."); }
             if (_sparseItems[entity] > 0) { throw new Exception ("Component already attached to entity."); }
 #endif
@@ -166,7 +166,7 @@ namespace Leopotam.EcsLite {
             _sparseItems[entity] = idx;
             _world.OnEntityChangeInternal (entity, _id, true);
             _world.Entities[entity].ComponentsCount++;
-#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
             _world.RaiseEntityChangeEvent (entity);
 #endif
             return ref _denseItems[idx];
@@ -174,7 +174,7 @@ namespace Leopotam.EcsLite {
 
         [MethodImpl (MethodImplOptions.AggressiveInlining)]
         public ref T Get (int entity) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (!_world.IsEntityAliveInternal (entity)) { throw new Exception ("Cant touch destroyed entity."); }
             if (_sparseItems[entity] == 0) { throw new Exception ("Not attached."); }
 #endif
@@ -183,14 +183,14 @@ namespace Leopotam.EcsLite {
 
         [MethodImpl (MethodImplOptions.AggressiveInlining)]
         public bool Has (int entity) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (!_world.IsEntityAliveInternal (entity)) { throw new Exception ("Cant touch destroyed entity."); }
 #endif
             return _sparseItems[entity] > 0;
         }
 
         public void Del (int entity) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (!_world.IsEntityAliveInternal (entity)) { throw new Exception ("Cant touch destroyed entity."); }
 #endif
             ref var sparseData = ref _sparseItems[entity];
@@ -208,7 +208,7 @@ namespace Leopotam.EcsLite {
                 sparseData = 0;
                 ref var entityData = ref _world.Entities[entity];
                 entityData.ComponentsCount--;
-#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
                 _world.RaiseEntityChangeEvent (entity);
 #endif
                 if (entityData.ComponentsCount == 0) {

--- a/src/components.cs
+++ b/src/components.cs
@@ -56,14 +56,14 @@ namespace Leopotam.EcsLite {
             _recycledItems = new int[recycledCapacity];
             _recycledItemsCount = 0;
             var isAutoReset = typeof (IEcsAutoReset<T>).IsAssignableFrom (_type);
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (!isAutoReset && _type.GetInterface ("IEcsAutoReset`1") != null) {
                 throw new Exception ($"IEcsAutoReset should have <{typeof (T).Name}> constraint for component \"{typeof (T).Name}\".");
             }
 #endif
             if (isAutoReset) {
                 var autoResetMethod = typeof (T).GetMethod (nameof (IEcsAutoReset<T>.AutoReset));
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                 if (autoResetMethod == null) {
                     throw new Exception (
                         $"IEcsAutoReset<{typeof (T).Name}> explicit implementation not supported, use implicit instead.");
@@ -112,7 +112,7 @@ namespace Leopotam.EcsLite {
         }
 
         void IEcsPool.SetRaw (int entity, object dataRaw) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (dataRaw == null || dataRaw.GetType () != _type) { throw new Exception ("Invalid component data."); }
             if (_sparseItems[entity] <= 0) { throw new Exception ("Component not attached to entity."); }
 #endif
@@ -120,7 +120,7 @@ namespace Leopotam.EcsLite {
         }
 
         void IEcsPool.AddRaw (int entity, object dataRaw) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (dataRaw == null || dataRaw.GetType () != _type) { throw new Exception ("Invalid component data."); }
 #endif
             ref var data = ref Add (entity);
@@ -148,7 +148,7 @@ namespace Leopotam.EcsLite {
         }
 
         public ref T Add (int entity) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (!_world.IsEntityAliveInternal (entity)) { throw new Exception ("Cant touch destroyed entity."); }
             if (_sparseItems[entity] > 0) { throw new Exception ("Component already attached to entity."); }
 #endif
@@ -166,7 +166,7 @@ namespace Leopotam.EcsLite {
             _sparseItems[entity] = idx;
             _world.OnEntityChangeInternal (entity, _id, true);
             _world.Entities[entity].ComponentsCount++;
-#if DEBUG || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
             _world.RaiseEntityChangeEvent (entity);
 #endif
             return ref _denseItems[idx];
@@ -174,7 +174,7 @@ namespace Leopotam.EcsLite {
 
         [MethodImpl (MethodImplOptions.AggressiveInlining)]
         public ref T Get (int entity) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (!_world.IsEntityAliveInternal (entity)) { throw new Exception ("Cant touch destroyed entity."); }
             if (_sparseItems[entity] == 0) { throw new Exception ("Not attached."); }
 #endif
@@ -183,14 +183,14 @@ namespace Leopotam.EcsLite {
 
         [MethodImpl (MethodImplOptions.AggressiveInlining)]
         public bool Has (int entity) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (!_world.IsEntityAliveInternal (entity)) { throw new Exception ("Cant touch destroyed entity."); }
 #endif
             return _sparseItems[entity] > 0;
         }
 
         public void Del (int entity) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (!_world.IsEntityAliveInternal (entity)) { throw new Exception ("Cant touch destroyed entity."); }
 #endif
             ref var sparseData = ref _sparseItems[entity];
@@ -208,7 +208,7 @@ namespace Leopotam.EcsLite {
                 sparseData = 0;
                 ref var entityData = ref _world.Entities[entity];
                 entityData.ComponentsCount--;
-#if DEBUG || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
                 _world.RaiseEntityChangeEvent (entity);
 #endif
                 if (entityData.ComponentsCount == 0) {

--- a/src/entities.cs
+++ b/src/entities.cs
@@ -20,7 +20,7 @@ namespace Leopotam.EcsLite {
         internal int Id;
         internal int Gen;
         internal EcsWorld World;
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
         // For using in IDE debugger.
         internal object[] DebugComponentsView {
             get {

--- a/src/entities.cs
+++ b/src/entities.cs
@@ -20,7 +20,7 @@ namespace Leopotam.EcsLite {
         internal int Id;
         internal int Gen;
         internal EcsWorld World;
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
         // For using in IDE debugger.
         internal object[] DebugComponentsView {
             get {

--- a/src/filters.cs
+++ b/src/filters.cs
@@ -75,7 +75,7 @@ namespace Leopotam.EcsLite {
 
 #if LEOECSLITE_FILTER_EVENTS
         public void AddEventListener (IEcsFilterEventListener eventListener) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             for (var i = 0; i < _eventListenersCount; i++) {
                 if (_eventListeners[i] == eventListener) {
                     throw new Exception ("Listener already subscribed.");
@@ -152,7 +152,7 @@ namespace Leopotam.EcsLite {
 
         [MethodImpl (MethodImplOptions.AggressiveInlining)]
         void Unlock () {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (_lockCount <= 0) {
                 throw new Exception ($"Invalid lock-unlock balance for \"{GetType ().Name}\".");
             }

--- a/src/filters.cs
+++ b/src/filters.cs
@@ -75,7 +75,7 @@ namespace Leopotam.EcsLite {
 
 #if LEOECSLITE_FILTER_EVENTS
         public void AddEventListener (IEcsFilterEventListener eventListener) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             for (var i = 0; i < _eventListenersCount; i++) {
                 if (_eventListeners[i] == eventListener) {
                     throw new Exception ("Listener already subscribed.");
@@ -152,7 +152,7 @@ namespace Leopotam.EcsLite {
 
         [MethodImpl (MethodImplOptions.AggressiveInlining)]
         void Unlock () {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (_lockCount <= 0) {
                 throw new Exception ($"Invalid lock-unlock balance for \"{GetType ().Name}\".");
             }

--- a/src/systems.cs
+++ b/src/systems.cs
@@ -99,7 +99,7 @@ namespace Leopotam.EcsLite {
             for (var i = _allSystems.Count - 1; i >= 0; i--) {
                 if (_allSystems[i] is IEcsDestroySystem destroySystem) {
                     destroySystem.Destroy (this);
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                     var worldName = CheckForLeakedEntities ();
                     if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {destroySystem.GetType ().Name}.Destroy()."); }
 #endif
@@ -108,7 +108,7 @@ namespace Leopotam.EcsLite {
             for (var i = _allSystems.Count - 1; i >= 0; i--) {
                 if (_allSystems[i] is IEcsPostDestroySystem postDestroySystem) {
                     postDestroySystem.PostDestroy (this);
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                     var worldName = CheckForLeakedEntities ();
                     if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {postDestroySystem.GetType ().Name}.PostDestroy()."); }
 #endif
@@ -119,7 +119,7 @@ namespace Leopotam.EcsLite {
         }
 
         public EcsSystems AddWorld (EcsWorld world, string name) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (string.IsNullOrEmpty (name)) { throw new System.Exception ("World name cant be null or empty."); }
 #endif
             _worlds[name] = world;
@@ -141,7 +141,7 @@ namespace Leopotam.EcsLite {
             foreach (var system in _allSystems) {
                 if (system is IEcsPreInitSystem initSystem) {
                     initSystem.PreInit (this);
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                     var worldName = CheckForLeakedEntities ();
                     if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {initSystem.GetType ().Name}.PreInit()."); }
 #endif
@@ -151,7 +151,7 @@ namespace Leopotam.EcsLite {
             foreach (var system in _allSystems) {
                 if (system is IEcsInitSystem initSystem) {
                     initSystem.Init (this);
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                     var worldName = CheckForLeakedEntities ();
                     if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {initSystem.GetType ().Name}.Init()."); }
 #endif
@@ -165,14 +165,14 @@ namespace Leopotam.EcsLite {
         public void Run () {
             for (int i = 0, iMax = _runSystemsCount; i < iMax; i++) {
                 _runSystems[i].Run (this);
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                 var worldName = CheckForLeakedEntities ();
                 if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {_runSystems[i].GetType ().Name}.Run()."); }
 #endif
             }
         }
 
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
         public string CheckForLeakedEntities () {
             if (_defaultWorld.CheckForLeakedEntities ()) { return "default"; }
             foreach (var pair in _worlds) {

--- a/src/systems.cs
+++ b/src/systems.cs
@@ -99,7 +99,7 @@ namespace Leopotam.EcsLite {
             for (var i = _allSystems.Count - 1; i >= 0; i--) {
                 if (_allSystems[i] is IEcsDestroySystem destroySystem) {
                     destroySystem.Destroy (this);
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                     var worldName = CheckForLeakedEntities ();
                     if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {destroySystem.GetType ().Name}.Destroy()."); }
 #endif
@@ -108,7 +108,7 @@ namespace Leopotam.EcsLite {
             for (var i = _allSystems.Count - 1; i >= 0; i--) {
                 if (_allSystems[i] is IEcsPostDestroySystem postDestroySystem) {
                     postDestroySystem.PostDestroy (this);
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                     var worldName = CheckForLeakedEntities ();
                     if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {postDestroySystem.GetType ().Name}.PostDestroy()."); }
 #endif
@@ -119,7 +119,7 @@ namespace Leopotam.EcsLite {
         }
 
         public EcsSystems AddWorld (EcsWorld world, string name) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (string.IsNullOrEmpty (name)) { throw new System.Exception ("World name cant be null or empty."); }
 #endif
             _worlds[name] = world;
@@ -141,7 +141,7 @@ namespace Leopotam.EcsLite {
             foreach (var system in _allSystems) {
                 if (system is IEcsPreInitSystem initSystem) {
                     initSystem.PreInit (this);
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                     var worldName = CheckForLeakedEntities ();
                     if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {initSystem.GetType ().Name}.PreInit()."); }
 #endif
@@ -151,7 +151,7 @@ namespace Leopotam.EcsLite {
             foreach (var system in _allSystems) {
                 if (system is IEcsInitSystem initSystem) {
                     initSystem.Init (this);
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                     var worldName = CheckForLeakedEntities ();
                     if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {initSystem.GetType ().Name}.Init()."); }
 #endif
@@ -165,14 +165,14 @@ namespace Leopotam.EcsLite {
         public void Run () {
             for (int i = 0, iMax = _runSystemsCount; i < iMax; i++) {
                 _runSystems[i].Run (this);
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                 var worldName = CheckForLeakedEntities ();
                 if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {_runSystems[i].GetType ().Name}.Run()."); }
 #endif
             }
         }
 
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
         public string CheckForLeakedEntities () {
             if (_defaultWorld.CheckForLeakedEntities ()) { return "default"; }
             foreach (var pair in _worlds) {

--- a/src/worlds.cs
+++ b/src/worlds.cs
@@ -35,18 +35,18 @@ namespace Leopotam.EcsLite {
         int _masksCount;
 
         bool _destroyed;
-#if DEBUG || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
         List<IEcsWorldEventListener> _eventListeners;
 
         public void AddEventListener (IEcsWorldEventListener listener) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (listener == null) { throw new Exception ("Listener is null."); }
 #endif
             _eventListeners.Add (listener);
         }
 
         public void RemoveEventListener (IEcsWorldEventListener listener) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (listener == null) { throw new Exception ("Listener is null."); }
 #endif
             _eventListeners.Remove (listener);
@@ -58,7 +58,7 @@ namespace Leopotam.EcsLite {
             }
         }
 #endif
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
         readonly List<int> _leakedEntities = new List<int> (512);
 
         internal bool CheckForLeakedEntities () {
@@ -99,14 +99,14 @@ namespace Leopotam.EcsLite {
             // masks.
             _masks = new Mask[64];
             _masksCount = 0;
-#if DEBUG || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
             _eventListeners = new List<IEcsWorldEventListener> (4);
 #endif
             _destroyed = false;
         }
 
         public void Destroy () {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (CheckForLeakedEntities ()) { throw new Exception ($"Empty entity detected before EcsWorld.Destroy()."); }
 #endif
             _destroyed = true;
@@ -122,7 +122,7 @@ namespace Leopotam.EcsLite {
             _allFilters.Clear ();
             _filtersByIncludedComponents = Array.Empty<List<EcsFilter>> ();
             _filtersByExcludedComponents = Array.Empty<List<EcsFilter>> ();
-#if DEBUG || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
             for (var ii = _eventListeners.Count - 1; ii >= 0; ii--) {
                 _eventListeners[ii].OnWorldDestroyed (this);
             }
@@ -152,7 +152,7 @@ namespace Leopotam.EcsLite {
                     for (int i = 0, iMax = _allFilters.Count; i < iMax; i++) {
                         _allFilters[i].ResizeSparseIndex (newSize);
                     }
-#if DEBUG || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
                     for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                         _eventListeners[ii].OnWorldResized (newSize);
                     }
@@ -161,10 +161,10 @@ namespace Leopotam.EcsLite {
                 entity = _entitiesCount++;
                 Entities[entity].Gen = 1;
             }
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             _leakedEntities.Add (entity);
 #endif
-#if DEBUG || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
             for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                 _eventListeners[ii].OnEntityCreated (entity);
             }
@@ -173,7 +173,7 @@ namespace Leopotam.EcsLite {
         }
 
         public void DelEntity (int entity) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             if (entity < 0 || entity >= _entitiesCount) {
                 throw new Exception ("Cant touch destroyed entity.");
             }
@@ -193,7 +193,7 @@ namespace Leopotam.EcsLite {
                         }
                     }
                 }
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                 if (entityData.ComponentsCount != 0) { throw new Exception ($"Invalid components count on entity {entity} => {entityData.ComponentsCount}."); }
 #endif
                 return;
@@ -203,7 +203,7 @@ namespace Leopotam.EcsLite {
                 Array.Resize (ref _recycledEntities, _recycledEntitiesCount << 1);
             }
             _recycledEntities[_recycledEntitiesCount++] = entity;
-#if DEBUG || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
             for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                 _eventListeners[ii].OnEntityDestroyed (entity);
             }
@@ -357,7 +357,7 @@ namespace Leopotam.EcsLite {
                     filter.AddEntity (i);
                 }
             }
-#if DEBUG || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
             for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                 _eventListeners[ii].OnFilterCreated (filter);
             }
@@ -373,7 +373,7 @@ namespace Leopotam.EcsLite {
                 if (includeList != null) {
                     foreach (var filter in includeList) {
                         if (IsMaskCompatible (filter.GetMask (), entity)) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                             if (filter.SparseEntities[entity] > 0) { throw new Exception ("Entity already in filter."); }
 #endif
                             filter.AddEntity (entity);
@@ -383,7 +383,7 @@ namespace Leopotam.EcsLite {
                 if (excludeList != null) {
                     foreach (var filter in excludeList) {
                         if (IsMaskCompatibleWithout (filter.GetMask (), entity, componentType)) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                             if (filter.SparseEntities[entity] == 0) { throw new Exception ("Entity not in filter."); }
 #endif
                             filter.RemoveEntity (entity);
@@ -395,7 +395,7 @@ namespace Leopotam.EcsLite {
                 if (includeList != null) {
                     foreach (var filter in includeList) {
                         if (IsMaskCompatible (filter.GetMask (), entity)) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                             if (filter.SparseEntities[entity] == 0) { throw new Exception ("Entity not in filter."); }
 #endif
                             filter.RemoveEntity (entity);
@@ -405,7 +405,7 @@ namespace Leopotam.EcsLite {
                 if (excludeList != null) {
                     foreach (var filter in excludeList) {
                         if (IsMaskCompatibleWithout (filter.GetMask (), entity, componentType)) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                             if (filter.SparseEntities[entity] > 0) { throw new Exception ("Entity already in filter."); }
 #endif
                             filter.AddEntity (entity);
@@ -474,7 +474,7 @@ namespace Leopotam.EcsLite {
             internal int IncludeCount;
             internal int ExcludeCount;
             internal int Hash;
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
             bool _built;
 #endif
 
@@ -490,7 +490,7 @@ namespace Leopotam.EcsLite {
                 IncludeCount = 0;
                 ExcludeCount = 0;
                 Hash = 0;
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                 _built = false;
 #endif
             }
@@ -498,7 +498,7 @@ namespace Leopotam.EcsLite {
             [MethodImpl (MethodImplOptions.AggressiveInlining)]
             public Mask Inc<T> () where T : struct {
                 var poolId = _world.GetPool<T> ().GetId ();
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                 if (_built) { throw new Exception ("Cant change built mask."); }
                 if (Array.IndexOf (Include, poolId, 0, IncludeCount) != -1) { throw new Exception ($"{typeof (T).Name} already in constraints list."); }
                 if (Array.IndexOf (Exclude, poolId, 0, ExcludeCount) != -1) { throw new Exception ($"{typeof (T).Name} already in constraints list."); }
@@ -514,7 +514,7 @@ namespace Leopotam.EcsLite {
             [MethodImpl (MethodImplOptions.AggressiveInlining)]
             public Mask Exc<T> () where T : struct {
                 var poolId = _world.GetPool<T> ().GetId ();
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                 if (_built) { throw new Exception ("Cant change built mask."); }
                 if (Array.IndexOf (Include, poolId, 0, IncludeCount) != -1) { throw new Exception ($"{typeof (T).Name} already in constraints list."); }
                 if (Array.IndexOf (Exclude, poolId, 0, ExcludeCount) != -1) { throw new Exception ($"{typeof (T).Name} already in constraints list."); }
@@ -526,7 +526,7 @@ namespace Leopotam.EcsLite {
 
             [MethodImpl (MethodImplOptions.AggressiveInlining)]
             public EcsFilter End (int capacity = 512) {
-#if DEBUG
+#if DEBUG && !RELEASE_TEST
                 if (_built) { throw new Exception ("Cant change built mask."); }
                 _built = true;
 #endif
@@ -561,7 +561,7 @@ namespace Leopotam.EcsLite {
         }
     }
 
-#if DEBUG || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
     public interface IEcsWorldEventListener {
         void OnEntityCreated (int entity);
         void OnEntityChanged (int entity);

--- a/src/worlds.cs
+++ b/src/worlds.cs
@@ -35,18 +35,18 @@ namespace Leopotam.EcsLite {
         int _masksCount;
 
         bool _destroyed;
-#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
         List<IEcsWorldEventListener> _eventListeners;
 
         public void AddEventListener (IEcsWorldEventListener listener) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (listener == null) { throw new Exception ("Listener is null."); }
 #endif
             _eventListeners.Add (listener);
         }
 
         public void RemoveEventListener (IEcsWorldEventListener listener) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (listener == null) { throw new Exception ("Listener is null."); }
 #endif
             _eventListeners.Remove (listener);
@@ -58,7 +58,7 @@ namespace Leopotam.EcsLite {
             }
         }
 #endif
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
         readonly List<int> _leakedEntities = new List<int> (512);
 
         internal bool CheckForLeakedEntities () {
@@ -99,14 +99,14 @@ namespace Leopotam.EcsLite {
             // masks.
             _masks = new Mask[64];
             _masksCount = 0;
-#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
             _eventListeners = new List<IEcsWorldEventListener> (4);
 #endif
             _destroyed = false;
         }
 
         public void Destroy () {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (CheckForLeakedEntities ()) { throw new Exception ($"Empty entity detected before EcsWorld.Destroy()."); }
 #endif
             _destroyed = true;
@@ -122,7 +122,7 @@ namespace Leopotam.EcsLite {
             _allFilters.Clear ();
             _filtersByIncludedComponents = Array.Empty<List<EcsFilter>> ();
             _filtersByExcludedComponents = Array.Empty<List<EcsFilter>> ();
-#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
             for (var ii = _eventListeners.Count - 1; ii >= 0; ii--) {
                 _eventListeners[ii].OnWorldDestroyed (this);
             }
@@ -152,7 +152,7 @@ namespace Leopotam.EcsLite {
                     for (int i = 0, iMax = _allFilters.Count; i < iMax; i++) {
                         _allFilters[i].ResizeSparseIndex (newSize);
                     }
-#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
                     for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                         _eventListeners[ii].OnWorldResized (newSize);
                     }
@@ -161,10 +161,10 @@ namespace Leopotam.EcsLite {
                 entity = _entitiesCount++;
                 Entities[entity].Gen = 1;
             }
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             _leakedEntities.Add (entity);
 #endif
-#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
             for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                 _eventListeners[ii].OnEntityCreated (entity);
             }
@@ -173,7 +173,7 @@ namespace Leopotam.EcsLite {
         }
 
         public void DelEntity (int entity) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (entity < 0 || entity >= _entitiesCount) {
                 throw new Exception ("Cant touch destroyed entity.");
             }
@@ -193,7 +193,7 @@ namespace Leopotam.EcsLite {
                         }
                     }
                 }
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                 if (entityData.ComponentsCount != 0) { throw new Exception ($"Invalid components count on entity {entity} => {entityData.ComponentsCount}."); }
 #endif
                 return;
@@ -203,7 +203,7 @@ namespace Leopotam.EcsLite {
                 Array.Resize (ref _recycledEntities, _recycledEntitiesCount << 1);
             }
             _recycledEntities[_recycledEntitiesCount++] = entity;
-#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
             for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                 _eventListeners[ii].OnEntityDestroyed (entity);
             }
@@ -357,7 +357,7 @@ namespace Leopotam.EcsLite {
                     filter.AddEntity (i);
                 }
             }
-#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
             for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                 _eventListeners[ii].OnFilterCreated (filter);
             }
@@ -373,7 +373,7 @@ namespace Leopotam.EcsLite {
                 if (includeList != null) {
                     foreach (var filter in includeList) {
                         if (IsMaskCompatible (filter.GetMask (), entity)) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                             if (filter.SparseEntities[entity] > 0) { throw new Exception ("Entity already in filter."); }
 #endif
                             filter.AddEntity (entity);
@@ -383,7 +383,7 @@ namespace Leopotam.EcsLite {
                 if (excludeList != null) {
                     foreach (var filter in excludeList) {
                         if (IsMaskCompatibleWithout (filter.GetMask (), entity, componentType)) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                             if (filter.SparseEntities[entity] == 0) { throw new Exception ("Entity not in filter."); }
 #endif
                             filter.RemoveEntity (entity);
@@ -395,7 +395,7 @@ namespace Leopotam.EcsLite {
                 if (includeList != null) {
                     foreach (var filter in includeList) {
                         if (IsMaskCompatible (filter.GetMask (), entity)) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                             if (filter.SparseEntities[entity] == 0) { throw new Exception ("Entity not in filter."); }
 #endif
                             filter.RemoveEntity (entity);
@@ -405,7 +405,7 @@ namespace Leopotam.EcsLite {
                 if (excludeList != null) {
                     foreach (var filter in excludeList) {
                         if (IsMaskCompatibleWithout (filter.GetMask (), entity, componentType)) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                             if (filter.SparseEntities[entity] > 0) { throw new Exception ("Entity already in filter."); }
 #endif
                             filter.AddEntity (entity);
@@ -474,7 +474,7 @@ namespace Leopotam.EcsLite {
             internal int IncludeCount;
             internal int ExcludeCount;
             internal int Hash;
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             bool _built;
 #endif
 
@@ -490,7 +490,7 @@ namespace Leopotam.EcsLite {
                 IncludeCount = 0;
                 ExcludeCount = 0;
                 Hash = 0;
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                 _built = false;
 #endif
             }
@@ -498,7 +498,7 @@ namespace Leopotam.EcsLite {
             [MethodImpl (MethodImplOptions.AggressiveInlining)]
             public Mask Inc<T> () where T : struct {
                 var poolId = _world.GetPool<T> ().GetId ();
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                 if (_built) { throw new Exception ("Cant change built mask."); }
                 if (Array.IndexOf (Include, poolId, 0, IncludeCount) != -1) { throw new Exception ($"{typeof (T).Name} already in constraints list."); }
                 if (Array.IndexOf (Exclude, poolId, 0, ExcludeCount) != -1) { throw new Exception ($"{typeof (T).Name} already in constraints list."); }
@@ -514,7 +514,7 @@ namespace Leopotam.EcsLite {
             [MethodImpl (MethodImplOptions.AggressiveInlining)]
             public Mask Exc<T> () where T : struct {
                 var poolId = _world.GetPool<T> ().GetId ();
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                 if (_built) { throw new Exception ("Cant change built mask."); }
                 if (Array.IndexOf (Include, poolId, 0, IncludeCount) != -1) { throw new Exception ($"{typeof (T).Name} already in constraints list."); }
                 if (Array.IndexOf (Exclude, poolId, 0, ExcludeCount) != -1) { throw new Exception ($"{typeof (T).Name} already in constraints list."); }
@@ -526,7 +526,7 @@ namespace Leopotam.EcsLite {
 
             [MethodImpl (MethodImplOptions.AggressiveInlining)]
             public EcsFilter End (int capacity = 512) {
-#if DEBUG && !RELEASE_TEST
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                 if (_built) { throw new Exception ("Cant change built mask."); }
                 _built = true;
 #endif
@@ -561,7 +561,7 @@ namespace Leopotam.EcsLite {
         }
     }
 
-#if DEBUG && !RELEASE_TEST || LEOECSLITE_WORLD_EVENTS
+#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
     public interface IEcsWorldEventListener {
         void OnEntityCreated (int entity);
         void OnEntityChanged (int entity);

--- a/src/worlds.cs
+++ b/src/worlds.cs
@@ -35,7 +35,7 @@ namespace Leopotam.EcsLite {
         int _masksCount;
 
         bool _destroyed;
-#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
+#if (DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS) || LEOECSLITE_WORLD_EVENTS
         List<IEcsWorldEventListener> _eventListeners;
 
         public void AddEventListener (IEcsWorldEventListener listener) {
@@ -99,7 +99,7 @@ namespace Leopotam.EcsLite {
             // masks.
             _masks = new Mask[64];
             _masksCount = 0;
-#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
+#if (DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS) || LEOECSLITE_WORLD_EVENTS
             _eventListeners = new List<IEcsWorldEventListener> (4);
 #endif
             _destroyed = false;
@@ -122,7 +122,7 @@ namespace Leopotam.EcsLite {
             _allFilters.Clear ();
             _filtersByIncludedComponents = Array.Empty<List<EcsFilter>> ();
             _filtersByExcludedComponents = Array.Empty<List<EcsFilter>> ();
-#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
+#if (DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS) || LEOECSLITE_WORLD_EVENTS
             for (var ii = _eventListeners.Count - 1; ii >= 0; ii--) {
                 _eventListeners[ii].OnWorldDestroyed (this);
             }
@@ -152,7 +152,7 @@ namespace Leopotam.EcsLite {
                     for (int i = 0, iMax = _allFilters.Count; i < iMax; i++) {
                         _allFilters[i].ResizeSparseIndex (newSize);
                     }
-#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
+#if (DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS) || LEOECSLITE_WORLD_EVENTS
                     for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                         _eventListeners[ii].OnWorldResized (newSize);
                     }
@@ -164,7 +164,7 @@ namespace Leopotam.EcsLite {
 #if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             _leakedEntities.Add (entity);
 #endif
-#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
+#if (DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS) || LEOECSLITE_WORLD_EVENTS
             for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                 _eventListeners[ii].OnEntityCreated (entity);
             }
@@ -203,7 +203,7 @@ namespace Leopotam.EcsLite {
                 Array.Resize (ref _recycledEntities, _recycledEntitiesCount << 1);
             }
             _recycledEntities[_recycledEntitiesCount++] = entity;
-#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
+#if (DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS) || LEOECSLITE_WORLD_EVENTS
             for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                 _eventListeners[ii].OnEntityDestroyed (entity);
             }
@@ -357,7 +357,7 @@ namespace Leopotam.EcsLite {
                     filter.AddEntity (i);
                 }
             }
-#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
+#if (DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS) || LEOECSLITE_WORLD_EVENTS
             for (int ii = 0, iMax = _eventListeners.Count; ii < iMax; ii++) {
                 _eventListeners[ii].OnFilterCreated (filter);
             }
@@ -561,7 +561,7 @@ namespace Leopotam.EcsLite {
         }
     }
 
-#if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS || LEOECSLITE_WORLD_EVENTS
+#if (DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS) || LEOECSLITE_WORLD_EVENTS
     public interface IEcsWorldEventListener {
         void OnEntityCreated (int entity);
         void OnEntityChanged (int entity);


### PR DESCRIPTION
I wanted to profile (through Unity) the systems by themselves, aka which parts have the biggest overhead/bad approaches.
But this becomes harder in EcsLite because of "#if DEBUG" defines. Not sure how it works without an engine, or other engines than Unity. 
But I think most engines that use C# (like Unity), have the DEBUG define hardcoded in to always be true.
Which means you can't test/profile LeoEcs Production/Release code directly in the engine/framework (unless you have access to these custom defines/have the code of the engine).

What's the reason behind this?
Easier to profile what will actually take away CPU cycles in the final build, rather than doing math in your head, like: "oh, I shouldn't include this check, because it's build only, and it takes 30% of our CPU cycles".

So I suggest something along this:
Another Custom define check like: SKIP_DEBUG, or RELEASE_TEST, or PRODUCTION_TEST.

Fairly sure it's important to have it be "niche", so someone doesn't have this define by default/from the start, by mistake. And doesn't get the proper exceptions in DEBUG.

If this is a "one-man scenario", aka I'm the only one that likes to profile against the production build, instead of debug build. I don't mind if this gets  rejected tbh, can just keep my fork for such changes.