### PR TITLE
Удалил каст систем к разным интерфейсам.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin
 obj
 Library
 Temp
+BenchmarkDotNet.Artifacts

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -1,0 +1,88 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Leopotam.EcsLite;
+
+[MemoryDiagnoser]
+public class Program
+{
+    public static void Main()
+    {
+        BenchmarkRunner.Run<Program>();
+    }
+
+    private static int iterations = 1000;
+    private static int entities = 1000;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+    }
+
+    [Benchmark]
+    public void MultiEntitySwitcherLeopotam()
+    {
+        var w = new EcsWorld();
+        var s = new EcsSystems(w);
+        s.Add(new AllEntityComponentSwitcherSystem1());
+        s.Add(new AllEntityComponentSwitcherSystem2());
+
+        for (var i = 0; i < entities; i++)
+        {
+            var e = w.NewEntity();
+            var pool = w.GetPool<ComponentLeo1>();
+            ref ComponentLeo1 c1 = ref pool.Add(e);
+        }
+        s.Init();
+
+        for (var i = 0; i < iterations / 10; i++)
+        {
+            s.Run();
+        }
+
+        s.Destroy();
+    }
+
+    internal class AllEntityComponentSwitcherSystem1 : IEcsSystem, IEcsRunSystem
+    {
+        public void Run(IEcsSystems systems)
+        {
+            EcsWorld world = systems.GetWorld();
+            var filter1 = world.Filter<ComponentLeo1>().End();
+            var comps1 = world.GetPool<ComponentLeo1>();
+            var comps2 = world.GetPool<ComponentLeo2>();
+
+            foreach (var entity in filter1)
+            {
+                comps2.Add(entity);
+                comps1.Del(entity);
+            }
+        }
+    }
+
+    internal class AllEntityComponentSwitcherSystem2 : IEcsSystem, IEcsRunSystem
+    {
+        public void Run(IEcsSystems systems)
+        {
+            EcsWorld world = systems.GetWorld();
+            var filter2 = world.Filter<ComponentLeo2>().End();
+            var comps1 = world.GetPool<ComponentLeo1>();
+            var comps2 = world.GetPool<ComponentLeo2>();
+
+            foreach (var entity in filter2)
+            {
+                comps1.Add(entity);
+                comps2.Del(entity);
+            }
+        }
+    }
+
+    internal struct ComponentLeo1
+    {
+        public int Id;
+    }
+
+    internal struct ComponentLeo2
+    {
+    }
+
+}

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -42,7 +42,7 @@ public class Program
         s.Destroy();
     }
 
-    internal class AllEntityComponentSwitcherSystem1 : IEcsSystem, IEcsRunSystem
+    internal class AllEntityComponentSwitcherSystem1 : IEcsSystem
     {
         public void Run(IEcsSystems systems)
         {
@@ -59,7 +59,7 @@ public class Program
         }
     }
 
-    internal class AllEntityComponentSwitcherSystem2 : IEcsSystem, IEcsRunSystem
+    internal class AllEntityComponentSwitcherSystem2 : IEcsSystem
     {
         public void Run(IEcsSystems systems)
         {

--- a/benchmark/benchmark.csproj
+++ b/benchmark/benchmark.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <DefineConstants>LEOECSLITE_FILTER_EVENTS</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="Cistern.ValueLinq" Version="0.1.14" />
+    <PackageReference Include="CodegenAnalysis.Benchmarks" Version="0.0.9-alpha" />
+    <PackageReference Include="NetFabric.Hyperlinq" Version="3.0.0-beta48" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\src.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmark/benchmark.md
+++ b/benchmark/benchmark.md
@@ -1,5 +1,14 @@
+With systems cast to interfaces:
+
 |                      Method |     Mean |     Error |    StdDev |   Median |   Gen 0 | Allocated |
 |---------------------------- |---------:|----------:|----------:|---------:|--------:|----------:|
-| With debug checks           | 10.96 ms |  0.049 ms | 0.041 ms  |          | 31.2500 |    163 KB |
+| With debug checks           | 10.96 ms |  0.049 ms |  0.041 ms |          | 31.2500 |    163 KB |
 | Filters enabled             | 9.690 ms | 0.1115 ms | 0.0988 ms |          | 31.2500 |    156 KB |
 | Default version             | 8.642 ms | 0.0926 ms | 0.0821 ms |          | 31.2500 |    156 KB |
+
+System cast to interface removed:
+
+|                      Method |     Mean |     Error |    StdDev |   Median |   Gen 0 | Allocated |
+| With debug checks           | 50.14 us |  0.425 us |  0.397 us |  24.2920 |  0.1221 |    100 KB |
+| Filters enabled             | 40.58 us |  0.776 us |  0.981 us |  22.8271 |  0.0610 |     93 KB |
+| Default version             | 41.42 us |  0.237 us |  0.222 us |  22.8271 |  0.0610 |     93 KB |

--- a/benchmark/benchmark.md
+++ b/benchmark/benchmark.md
@@ -1,0 +1,5 @@
+|                      Method |     Mean |     Error |    StdDev |   Median |   Gen 0 | Allocated |
+|---------------------------- |---------:|----------:|----------:|---------:|--------:|----------:|
+| With debug checks           | 10.96 ms |  0.049 ms | 0.041 ms  |          | 31.2500 |    163 KB |
+| Filters enabled             | 9.690 ms | 0.1115 ms | 0.0988 ms |          | 31.2500 |    156 KB |
+| Default version             | 8.642 ms | 0.0926 ms | 0.0821 ms |          | 31.2500 |    156 KB |

--- a/src/src.csproj
+++ b/src/src.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/src.csproj
+++ b/src/src.csproj
@@ -4,5 +4,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
+    <DefineConstants>DEBUG</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/systems.cs
+++ b/src/systems.cs
@@ -10,30 +10,13 @@ using Unity.IL2CPP.CompilerServices;
 #endif
 
 namespace Leopotam.EcsLite {
-    public interface IEcsSystem { }
-
-    public interface IEcsPreInitSystem : IEcsSystem {
-        void PreInit (IEcsSystems systems);
-    }
-
-    public interface IEcsInitSystem : IEcsSystem {
-        void Init (IEcsSystems systems);
-    }
-
-    public interface IEcsRunSystem : IEcsSystem {
-        void Run (IEcsSystems systems);
-    }
-
-    public interface IEcsPostRunSystem : IEcsSystem {
-        void PostRun (IEcsSystems systems);
-    }
-
-    public interface IEcsDestroySystem : IEcsSystem {
-        void Destroy (IEcsSystems systems);
-    }
-
-    public interface IEcsPostDestroySystem : IEcsSystem {
-        void PostDestroy (IEcsSystems systems);
+    public class IEcsSystem {
+        public virtual void PreInit (IEcsSystems systems){}
+        public virtual void Init (IEcsSystems systems){}
+        public virtual void Run (IEcsSystems systems){}
+        public virtual void PostRun (IEcsSystems systems){}
+        public virtual void Destroy (IEcsSystems systems){}
+        public virtual void PostDestroy (IEcsSystems systems){}
     }
 
     public interface IEcsSystems {
@@ -56,8 +39,6 @@ namespace Leopotam.EcsLite {
         readonly EcsWorld _defaultWorld;
         readonly Dictionary<string, EcsWorld> _worlds;
         readonly List<IEcsSystem> _allSystems;
-        readonly List<IEcsRunSystem> _runSystems;
-        readonly List<IEcsPostRunSystem> _postRunSystems;
         readonly object _shared;
 #if DEBUG
         protected bool _inited;
@@ -68,8 +49,6 @@ namespace Leopotam.EcsLite {
             _shared = shared;
             _worlds = new Dictionary<string, EcsWorld> (8);
             _allSystems = new List<IEcsSystem> (128);
-            _runSystems = new List<IEcsRunSystem> (128);
-            _postRunSystems = new List<IEcsPostRunSystem> (128);
         }
 
         public virtual T GetShared<T> () where T : class {
@@ -104,12 +83,6 @@ namespace Leopotam.EcsLite {
             if (_inited) { throw new System.Exception ("Cant add system after initialization."); }
 #endif
             _allSystems.Add (system);
-            if (system is IEcsRunSystem runSystem) {
-                _runSystems.Add (runSystem);
-            }
-            if (system is IEcsPostRunSystem postRunSystem) {
-                _postRunSystems.Add (postRunSystem);
-            }
             return this;
         }
 
@@ -122,22 +95,18 @@ namespace Leopotam.EcsLite {
             if (_inited) { throw new System.Exception ("Already initialized."); }
 #endif
             foreach (var system in _allSystems) {
-                if (system is IEcsPreInitSystem initSystem) {
-                    initSystem.PreInit (this);
+                system.PreInit (this);
 #if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
-                    var worldName = CheckForLeakedEntities (this);
-                    if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {initSystem.GetType ().Name}.PreInit()."); }
+                var worldName = CheckForLeakedEntities (this);
+                if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {system.GetType ().Name}.PreInit()."); }
 #endif
-                }
             }
             foreach (var system in _allSystems) {
-                if (system is IEcsInitSystem initSystem) {
-                    initSystem.Init (this);
+                system.Init (this);
 #if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
-                    var worldName = CheckForLeakedEntities (this);
-                    if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {initSystem.GetType ().Name}.Init()."); }
+                var worldName = CheckForLeakedEntities (this);
+                if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {system.GetType ().Name}.Init()."); }
 #endif
-                }
             }
 #if DEBUG
             _inited = true;
@@ -148,45 +117,39 @@ namespace Leopotam.EcsLite {
 #if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
             if (!_inited) { throw new System.Exception ("Cant run without initialization."); }
 #endif
-            for (int i = 0, iMax = _runSystems.Count; i < iMax; i++) {
-                _runSystems[i].Run (this);
+            for (int i = 0, iMax = _allSystems.Count; i < iMax; i++) {
+                _allSystems[i].Run (this);
 #if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                 var worldName = CheckForLeakedEntities (this);
-                if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {_runSystems[i].GetType ().Name}.Run()."); }
+                if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {_allSystems[i].GetType ().Name}.Run()."); }
 #endif
             }
-            for (int i = 0, iMax = _postRunSystems.Count; i < iMax; i++) {
-                _postRunSystems[i].PostRun (this);
+            for (int i = 0, iMax = _allSystems.Count; i < iMax; i++) {
+                _allSystems[i].PostRun (this);
 #if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
                 var worldName = CheckForLeakedEntities (this);
-                if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {_postRunSystems[i].GetType ().Name}.PostRun()."); }
+                if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {_allSystems[i].GetType ().Name}.PostRun()."); }
 #endif
             }
         }
 
         public virtual void Destroy () {
             for (var i = _allSystems.Count - 1; i >= 0; i--) {
-                if (_allSystems[i] is IEcsDestroySystem destroySystem) {
-                    destroySystem.Destroy (this);
+                _allSystems[i].Destroy (this);
 #if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
-                    var worldName = CheckForLeakedEntities (this);
-                    if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {destroySystem.GetType ().Name}.Destroy()."); }
+                var worldName = CheckForLeakedEntities (this);
+                if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {_allSystems[i].GetType ().Name}.Destroy()."); }
 #endif
-                }
             }
             for (var i = _allSystems.Count - 1; i >= 0; i--) {
-                if (_allSystems[i] is IEcsPostDestroySystem postDestroySystem) {
-                    postDestroySystem.PostDestroy (this);
+                _allSystems[i].PostDestroy (this);
 #if DEBUG && !LEOECSLITE_NO_SANITIZE_CHECKS
-                    var worldName = CheckForLeakedEntities (this);
-                    if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {postDestroySystem.GetType ().Name}.PostDestroy()."); }
+                var worldName = CheckForLeakedEntities (this);
+                if (worldName != null) { throw new System.Exception ($"Empty entity detected in world \"{worldName}\" after {_allSystems[i].GetType ().Name}.PostDestroy()."); }
 #endif
-                }
             }
             _worlds.Clear ();
             _allSystems.Clear ();
-            _runSystems.Clear ();
-            _postRunSystems.Clear ();
 #if DEBUG
             _inited = false;
 #endif


### PR DESCRIPTION
В этом пул реквесте:

- В первом коммите я добавил бенчмарки с использованием [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) чтобы сравнить произвдительность разных вариантов флагов компиляции (DEBUG, LEOECSLITE_FILTER_EVENTS и без флагов) в релиз версии. (Конечно тест слегка искусственный, но он покрывает основные юзкейсы - разные фильтры, ентити прыгающие между ними, несколько систем)

Результат:  Выполнение заняло 10 миллисекунд

- Во втором коммите я убрал интерфейсы и создал один класс с пачкой виртуальных методовв файле 'systems.cs'. И прогнал тот же бенчмарк для тех же параметров (результат там же во второй таблице файла benchmark.md)

Ресультат: Выполнение заняло 40 наносекунд (250 раз быстрее)

Бенчмарк запускался командой
`dotnet run -c Release`
из папки benchmark

Т.к. изменение по скорости достаточно значительное у меня возник вопрос - у вас есть юнит тесты? Чтобы посмотреть что ничего не сломалось.